### PR TITLE
Fix Backend Image Build Error with NLTK

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /code
 RUN ls -l
 COPY ./requirements.txt /code/
 RUN pip install -r requirements.txt
+COPY ./nltk-download.py /code/
 RUN python nltk-download.py
 COPY . .
 


### PR DESCRIPTION
This fixes an error when trying the build the backend docker image and it cannot find the nltk-download.py file