### PR TITLE
Fix Refresh Bug when page fails to reload on chat page

### DIFF
--- a/src/backend/config/urls.py
+++ b/src/backend/config/urls.py
@@ -22,5 +22,5 @@ from django.http import JsonResponse
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('chat/', include('api.urls')),
+    path('api/', include('api.urls')),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/src/nginx-setup.conf
+++ b/src/nginx-setup.conf
@@ -3,9 +3,10 @@ server {
 
     location / {
       root /usr/share/nginx/html;
+      try_files $uri $uri/ /index.html;
     }
 
-    location /chat/ {
+    location /api/ {
         proxy_pass http://backend:2022;
         proxy_set_header Host $host;
     }

--- a/src/web/src/pages/Chat.jsx
+++ b/src/web/src/pages/Chat.jsx
@@ -94,7 +94,7 @@ export const Chat = ({name}) => {
     useEffect(() => {
         if(!firstRender){
             const getResponse = async () => {
-                fetch(`http://localhost:2022/chat/?brock=${latestMessage}`)
+                fetch(`http://localhost/api/?brock=${latestMessage}`)
                     .then(response => response.json())
                     .then(data => {
                             setMessages((prevMessages) => [

--- a/src/web/src/pages/ChatCG.jsx
+++ b/src/web/src/pages/ChatCG.jsx
@@ -95,7 +95,7 @@ export const ChatCG = ({name}) => {
     useEffect(() => {
         if(!firstRender){
             const getResponse = async () => {
-                fetch(`http://localhost:2022/chat/?cg=${latestMessage}`)
+                fetch(`http://localhost:/api/?cg=${latestMessage}`)
                     .then(response => response.json())
                     .then(data => {
                             setMessages((prevMessages) => [


### PR DESCRIPTION
This fixes an issue that occurs when you refresh the page on the chat page due to conflicting paths